### PR TITLE
input title, wrapper 컴포넌트 생성

### DIFF
--- a/src/components/InputWithTitle.tsx
+++ b/src/components/InputWithTitle.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import PlanInputTitle from './PlanInputTitle';
+
+interface InputFieldProps {
+  title: string;
+  size?: 'sm' | 'md';
+  children: React.ReactNode;
+}
+
+const WrapperGap = {
+  sm: 'gap-3',
+  md: 'gap-[9px] md:gap-3'
+};
+
+export default function InputWithTitle({ title, size = 'md', children }: InputFieldProps) {
+  return (
+    <div className={`flex flex-col ${WrapperGap[size]}`}>
+      <PlanInputTitle size={size}>{title}</PlanInputTitle>
+      {children}
+    </div>
+  );
+}

--- a/src/components/InputWithTitle.tsx
+++ b/src/components/InputWithTitle.tsx
@@ -10,7 +10,7 @@ interface InputFieldProps {
 
 const WrapperGap = {
   sm: 'gap-3',
-  md: 'gap-[9px] md:gap-3'
+  md: 'gap-[0.5625rem] md:gap-3'
 };
 
 export default function InputWithTitle({ title, size = 'md', children }: InputFieldProps) {

--- a/src/components/PlanInputTitle.tsx
+++ b/src/components/PlanInputTitle.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface FormLabelProps {
+  children: React.ReactNode;
+  size?: 'sm' | 'md';
+}
+
+const TitleSize = {
+  sm: 'font-subtitle-2',
+  md: 'font-title-4'
+};
+
+export default function PlanInputTitle({ children, size = 'md' }: FormLabelProps) {
+  return <h3 className={`${TitleSize[size]} text-black-01`}>{children}</h3>;
+}

--- a/src/components/common/input/SearchInput.tsx
+++ b/src/components/common/input/SearchInput.tsx
@@ -25,7 +25,7 @@ export default function SearchInput({ searchString: initialSearchString = '', on
   };
 
   return (
-    <div className="bg-gray-03 flex h-10 rounded-[5px] px-3 pb-2 pt-[10px]">
+    <div className="flex h-10 rounded-[5px] bg-gray-03 px-3 pb-2 pt-[10px]">
       <Input id="search" value={searchString} className="w-full bg-inherit" onChange={handleSearchStringChange} />
       {searchString && (
         <button type="button" onClick={handleSearchStringReset}>


### PR DESCRIPTION
## ➕ Jira 이슈 링크 (필수)

- [T6-118](https://jh0292jh.atlassian.net/browse/T6-118)
  <br/>

## 🔎 작업 내용 (필수)

- [x] 초기 세팅 페이지 input 제목과 input을 묶어서 컴포넌트로 생성
      <br/>

## 이미지 첨부 (권장)

![image](https://github.com/TravelLaboratory/frontend/assets/129285524/fd4c0833-2b31-401b-b4af-da1d50d023aa)
<br/>
<br/>


[T6-118]: https://jh0292jh.atlassian.net/browse/T6-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ