### PR TITLE
여행 초기 계획 수정페이지에서 여행 초기 생성 페이지로 리다이렉

### DIFF
--- a/src/apis/useArticle/article.type.ts
+++ b/src/apis/useArticle/article.type.ts
@@ -13,6 +13,10 @@ export interface ArticleFormData {
   travelStyle: string[];
 }
 
+export interface GetArticleFormData extends ArticleFormData {
+  isEditable: boolean;
+}
+
 export interface ArticleRequestFormData {
   title: string;
   location: { place_id: string; address: string; city: string }[];
@@ -22,4 +26,8 @@ export interface ArticleRequestFormData {
   travel_companion: string;
   style?: string[];
   travel_style?: string[];
+}
+
+export interface GetArticleRequestFormData extends ArticleRequestFormData {
+  is_editable: boolean;
 }

--- a/src/apis/useArticle/fetch.ts
+++ b/src/apis/useArticle/fetch.ts
@@ -1,6 +1,6 @@
 import returnFetch, { ReturnFetchDefaultOptions } from 'return-fetch';
 
-import type { ArticleFormData, ArticleRequestFormData } from '@/apis/useArticle/article.type';
+import type { ArticleFormData, ArticleRequestFormData, GetArticleFormData } from '@/apis/useArticle/article.type';
 import getAuthToken from '@/apis/utils/getAuthToken';
 
 import API_URL from '../constants/url';
@@ -61,7 +61,7 @@ const ArticleService = {
       throw new Error(data.local_message);
     }
 
-    const formattedData: ArticleFormData = formatArticleInitialDataFromResponse(data);
+    const formattedData: GetArticleFormData = formatArticleInitialDataFromResponse(data);
 
     return formattedData;
   },

--- a/src/apis/utils/formatArticleInitialData.ts
+++ b/src/apis/utils/formatArticleInitialData.ts
@@ -1,7 +1,12 @@
 /* eslint-disable camelcase */
 import { dateRequestFormat } from '@/libs/utils/dateFormatter';
 
-import { ArticleFormData, ArticleRequestFormData } from '../useArticle/article.type';
+import {
+  ArticleFormData,
+  ArticleRequestFormData,
+  GetArticleFormData,
+  GetArticleRequestFormData
+} from '../useArticle/article.type';
 
 export const formatArticleInitialDataForRequest = ({
   title,
@@ -37,9 +42,10 @@ export const formatArticleInitialDataFromResponse = ({
   end_at,
   travel_companion,
   travel_style,
-  expense
-}: ArticleRequestFormData) => {
-  const formatData: ArticleFormData = {
+  expense,
+  is_editable
+}: GetArticleRequestFormData) => {
+  const formatData: GetArticleFormData = {
     title,
     location: location.map(({ place_id, address, city }) => ({ placeId: place_id, address, city })),
     date: {
@@ -47,7 +53,8 @@ export const formatArticleInitialDataFromResponse = ({
       to: new Date(end_at)
     },
     travelCompanion: travel_companion,
-    travelStyle: travel_style || []
+    travelStyle: travel_style || [],
+    isEditable: is_editable
   };
 
   if (expense) {

--- a/src/app/(plan)/plan/initial/[id]/page.tsx
+++ b/src/app/(plan)/plan/initial/[id]/page.tsx
@@ -1,8 +1,14 @@
+import { redirect } from 'next/navigation';
+
 import ArticleService from '@/apis/useArticle/fetch';
 import PlanInitialForm from '@/components/PlanInitialForm';
 
 async function Plan({ params }: { params: { id: string } }) {
   const articleData = await ArticleService.getArticle(params.id);
+
+  if (!articleData.isEditable) {
+    redirect('/plan/initial');
+  }
 
   return <PlanInitialForm articlePageId={params.id} articleData={articleData} />;
 }

--- a/src/components/PlanInitialForm.tsx
+++ b/src/components/PlanInitialForm.tsx
@@ -30,7 +30,7 @@ export default function PlanInitialForm({
   articleData
 }: {
   articlePageId?: string;
-  articleData: ArticleFormData;
+  articleData?: ArticleFormData;
 }) {
   const router = useRouter();
   const [isEditFinished, setIsEditFinished] = useState(false);


### PR DESCRIPTION
## ➕ Jira 이슈 링크 (필수)

- [T6-182](https://jh0292jh.atlassian.net/browse/T6-182)
  <br/>

## 🔎 작업 내용 (필수)

- [ ] 내가 작성하지 않은 여행 계획의 여행 초기 수정 페이지로 접근한다면 여행 초기 생성 페이지로 이동합니다.
- [ ] `/plan/initial/$[id}` -> `/plan/initial`
      <br/>

## 이미지 첨부 (권장)

![chrome_ECJ0DItjBt](https://github.com/TravelLaboratory/frontend/assets/129285524/c7bf05cd-9db9-47e6-9559-b466da10798a)
<br/>
<br/>


[T6-182]: https://jh0292jh.atlassian.net/browse/T6-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ